### PR TITLE
rename "titter" to "pinger" for fix hook

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ login:
   command: sh -c "cd /srv/www && cp /srv/config/config.json . && node server.js"
 
 pinger:
-  image: webrunes/titter-wrio-app
+  image: webrunes/pinger-wrio-app
   ports:
    - "5001:5001"
   restart: always
@@ -113,4 +113,3 @@ iframely:
 #     - "8081:8081"
 #  privileged: true
 #  command: sh -c "echo 123 && app -listen-addr 0.0.0.0:8081 -configdir /config"
-

--- a/hooks/pinger.sh
+++ b/hooks/pinger.sh
@@ -2,4 +2,4 @@
 
 OLDPORTS=( `docker ps | grep wriodockerproduction_titter_1 | awk '{print $1}'` )
 cd /srv/docker/Wrio-Docker-Production
-docker pull webrunes/titter-wrio-app && /usr/local/bin/docker-compose up -d pinger
+docker pull webrunes/pinger-wrio-app && /usr/local/bin/docker-compose up -d pinger


### PR DESCRIPTION
This fix related to issue:
https://github.com/webRunes/WRIO-InternetOS/issues/1370
with problem Change "Donated 0 THX" to "Credited 0 CRD"

Any valid updates of Pinger container will be applied at hub in future.